### PR TITLE
Fix sample app: SpringBootServletInitializer not found

### DIFF
--- a/ff4j-spring-boot-sample/pom.xml
+++ b/ff4j-spring-boot-sample/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.3.2.RELEASE</version>
+        <version>1.5.3.RELEASE</version>
     </parent>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
The class path for SpringBootServletInitializer in the newest versions of Spring Boot was changed from org.springframework.boot.context.web to org.springframework.boot.web.support. Since the parent project uses 1.5.3.RELEASE version of Spring Boot, fails the sample app that uses the older version.